### PR TITLE
Ignore MIME types without extensions

### DIFF
--- a/lib/mime/application.ex
+++ b/lib/mime/application.ex
@@ -64,7 +64,7 @@ defmodule MIME.Application do
               |> String.trim()
               |> String.split()
 
-            [{type, exts}]
+            if exts == [], do: [], else: [{type, exts}]
           end
         end)
 


### PR DESCRIPTION
Given the fact that `priv/mime.types` contains a bunch of MIME types
without any extension associated, we can discard those values, this
change should improve the compilation time.

```console
$ grep -v "^#" mime.types | awk '{print NF}' | sort -n | uniq -c | head -n5
   6 0
 847 1
 755 2
  98 3
  32 4
```

Some quick tests that I did:

```console
master λ touch priv/mime.types
master λ time mix compile
Compiling 1 file (.ex)
        2.36 real         2.09 user         0.56 sys
master λ touch priv/mime.types
master λ time mix compile
Compiling 1 file (.ex)
        2.36 real         2.11 user         0.55 sys
```

This branch:

```console
reduce_compilation_time λ touch priv/mime.types
reduce_compilation_time λ time mix compile
Compiling 1 file (.ex)
        1.74 real         1.54 user         0.47 sys
reduce_compilation_time λ
touch priv/mime.types
Compiling 1 file (.ex)
        1.76 real         1.54 user         0.48 sys
```