### PR TITLE
Add application/wasm as a valid mime type

### DIFF
--- a/priv/mime.types
+++ b/priv/mime.types
@@ -1258,6 +1258,7 @@ application/vnd.zul				zir zirz
 application/vnd.zzazz.deck+xml			zaz
 application/voicexml+xml			vxml
 application/vq-rtcp-xr
+application/wasm                wasm
 application/watcherinfo+xml			wif
 application/whoispp-query
 application/whoispp-response


### PR DESCRIPTION
Running into an issue while serving wasm files from phoenix. 
```
Uncaught (in promise) TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.
```

I assume adding this pr would provide the correct response type. 

Currently, my response's content type is `content-type: application/octet-stream`. 
