### PR TITLE
Normalize extensions

### DIFF
--- a/lib/mime/application.ex
+++ b/lib/mime/application.ex
@@ -57,7 +57,7 @@ defmodule MIME.Application do
       mapping =
         for line <- stream,
             not String.starts_with?(line, ["#", "\n"]),
-            [type | exts] = line |> String.trim() |> String.split(),
+            [type | exts] = line |> String.trim() |> String.downcase() |> String.split(),
             exts != [],
             do: {type, exts}
 
@@ -102,7 +102,7 @@ defmodule MIME.Application do
       """
       @spec extensions(String.t()) :: [String.t()]
       def extensions(type) do
-        mime_to_ext(type) || []
+        mime_to_ext(downcase(type, "")) || []
       end
 
       @default_type "application/octet-stream"

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -12,6 +12,8 @@ defmodule MIMETest do
   test "extensions/1" do
     assert "json" in extensions("application/json")
     assert extensions("application/vnd.api+json") == ["json-api"]
+    assert extensions("audio/amr") == ["amr"]
+    assert extensions("IMAGE/PNG") == ["png"]
   end
 
   test "type/1" do


### PR DESCRIPTION
## Summary

This PR normalizes the mime and extensions all as lower case

## Related

Closes #38

## Notes

I do have one irk, was it safe to downcase the entire line mime and extension, or should I have only downcased the extension, oh well