### PR TITLE
Ignore params and detect subtype suffix in extensions/1

### DIFF
--- a/lib/mime/application.ex
+++ b/lib/mime/application.ex
@@ -177,7 +177,7 @@ defmodule MIME.Application do
       end
 
       defp strip_params(string) do
-        string |> String.split(";", parts: 2) |> hd()
+        string |> :binary.split(";") |> hd()
       end
 
       defp downcase(<<h, t::binary>>, acc) when h in ?A..?Z,

--- a/lib/mime/application.ex
+++ b/lib/mime/application.ex
@@ -96,6 +96,9 @@ defmodule MIME.Application do
           iex> MIME.extensions("application/json")
           ["json"]
 
+          iex> MIME.extensions("application/vnd.custom+xml")
+          ["xml"]
+
           iex> MIME.extensions("foo/bar")
           []
 
@@ -107,7 +110,14 @@ defmodule MIME.Application do
           |> strip_params()
           |> downcase("")
 
-        mime_to_ext(mime) || []
+        mime_to_ext(mime) || suffix(mime) || []
+      end
+
+      defp suffix(type) do
+        case String.split(type, "+") do
+          [type_subtype_without_suffix, suffix] -> [suffix]
+          _ -> nil
+        end
       end
 
       @default_type "application/octet-stream"

--- a/lib/mime/application.ex
+++ b/lib/mime/application.ex
@@ -102,7 +102,12 @@ defmodule MIME.Application do
       """
       @spec extensions(String.t()) :: [String.t()]
       def extensions(type) do
-        mime_to_ext(downcase(type, "")) || []
+        mime =
+          type
+          |> strip_params()
+          |> downcase("")
+
+        mime_to_ext(mime) || []
       end
 
       @default_type "application/octet-stream"
@@ -159,6 +164,10 @@ defmodule MIME.Application do
           "." <> ext -> type(downcase(ext, ""))
           _ -> @default_type
         end
+      end
+
+      defp strip_params(string) do
+        string |> String.split(";", parts: 2) |> hd()
       end
 
       defp downcase(<<h, t::binary>>, acc) when h in ?A..?Z,

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -19,6 +19,9 @@ defmodule MIMETest do
     assert extensions("IMAGE/PNG") == ["png"]
 
     assert extensions("application/json; charset=utf-8") == ["json"]
+
+    assert extensions("application/vnd.custom+xml") == ["xml"]
+    assert extensions("application/vnd.custom+xml+xml") == []
   end
 
   test "type/1" do

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -7,13 +7,18 @@ defmodule MIMETest do
   test "valid?/1" do
     assert valid?("application/json")
     refute valid?("application/prs.vacation-photos")
+
+    refute valid?("application/JSON")
+    refute valid?("application/json; charset=utf-8")
   end
 
   test "extensions/1" do
-    assert "json" in extensions("application/json")
+    assert extensions("application/json") == ["json"]
     assert extensions("application/vnd.api+json") == ["json-api"]
     assert extensions("audio/amr") == ["amr"]
     assert extensions("IMAGE/PNG") == ["png"]
+
+    assert extensions("application/json; charset=utf-8") == ["json"]
   end
 
   test "type/1" do

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -7,9 +7,6 @@ defmodule MIMETest do
   test "valid?/1" do
     assert valid?("application/json")
     refute valid?("application/prs.vacation-photos")
-
-    refute valid?("application/JSON")
-    refute valid?("application/json; charset=utf-8")
   end
 
   test "extensions/1" do


### PR DESCRIPTION
  * Ignore media type params

  * Detect subtype suffix in extensions/1
    See: https://tools.ietf.org/html/rfc6838#section-4.2.8