### PR TITLE
Deprecate MIME.valid?(type) in favour of MIME.extensions(type) != []

### DIFF
--- a/lib/mime/application.ex
+++ b/lib/mime/application.ex
@@ -68,19 +68,8 @@ defmodule MIME.Application do
         unquote(Macro.escape(custom_types))
       end
 
-      @doc """
-      Returns whether a MIME type is registered.
-
-      ## Examples
-
-          iex> MIME.valid?("text/plain")
-          true
-
-          iex> MIME.valid?("foo/bar")
-          false
-
-      """
-      @spec valid?(String.t()) :: boolean
+      @doc false
+      @deprecated "Use MIME.extensions(type) != [] instead"
       def valid?(type) do
         is_list(mime_to_ext(type))
       end

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -4,11 +4,6 @@ defmodule MIMETest do
   import MIME
   doctest MIME
 
-  test "valid?/1" do
-    assert valid?("application/json")
-    refute valid?("application/prs.vacation-photos")
-  end
-
   test "extensions/1" do
     assert "json" in extensions("application/json")
     assert extensions("application/vnd.api+json") == ["json-api"]


### PR DESCRIPTION
`valid?/1` implies performing validations which we don't necessarily want to do. For example, for `extensions/1` we simply want to ignore params (e.g. `; charset=utf-8`) instead of validating if it's in the right shape first.
