### PR TITLE
Update mime.types: Sync with IANA as of 2021-02-27

### DIFF
--- a/priv/mime.types
+++ b/priv/mime.types
@@ -1,8 +1,8 @@
 # https://pagure.io/mailcap/blob/master/f/mime.types
 
-# Updated:                2020-04-22
-# Synced with IANA as of: 2020-04-22
-# Reference: https://pagure.io/mailcap/c/817d30ef7d4c4f7bbf44fbeff329e0c54e8be73c
+# Updated:                2021-04-27
+# Synced with IANA as of: 2021-02-27
+# Reference: https://pagure.io/mailcap/c/4a12cc7caeb4a74626e8e6aedf38e7223b28e982
 
 # This file controls what Internet media types are sent to the client for
 # given file extension(s).  Sending the correct media type to the client
@@ -56,7 +56,8 @@ application/beep+xml
 application/calendar+json
 application/calendar+xml			xcs
 application/call-completion
-application/cals-1840
+application/CALS-1840
+application/captive+json
 application/cap+xml
 application/cbor				cbor
 application/cbor-seq
@@ -74,6 +75,7 @@ application/CEA					cea
 application/cea-2018+xml
 application/cellml+xml				cellml cml
 application/cfw
+application/clr                     1clr
 application/clue_info+xml			clue
 application/clue+xml
 application/cms					cmsc
@@ -113,10 +115,13 @@ application/dssc+der				dssc
 application/dssc+xml				xdssc
 application/dvcs				dvc
 application/ecmascript				es
-application/EDI-Consent
+application/EDI-consent
 application/EDI-X12
 application/EDIFACT
 application/efi					efi
+application/elm+json
+application/elm+xml
+application/EmergencyCallData.cap+xml
 application/EmergencyCallData.Comment+xml
 application/EmergencyCallData.Control+xml
 application/EmergencyCallData.DeviceInfo+xml
@@ -167,16 +172,17 @@ application/index.obj
 application/index.response
 application/index.vnd
 application/inkml+xml				ink inkml
-application/iotp
+application/IOTP
 application/ipfix				ipfix
 application/ipp
-application/isup
+application/ISUP
 application/its+xml				its
 application/javascript				js
 application/jf2feed+json
 application/jose
 application/jose+json
 application/jrd+json				jrd
+application/jscalendar+json
 application/json				json
 application/json-patch+json			json-patch
 application/json-seq
@@ -223,6 +229,7 @@ application/metalink4+xml			meta4
 application/mets+xml				mets
 application/MF4					mf4
 application/mikey
+application/mipc                h5
 application/mmt-aei+xml				maei
 application/mmt-usd+xml				musd
 application/mods+xml				mods
@@ -254,14 +261,16 @@ application/news-transmission
 application/nlsml+xml
 application/node
 application/nss
+application/oauth-authz-req+jwt
 application/ocsp-request			orq
 application/ocsp-response			ors
 application/octet-stream		bin lha lzh exe class so dll img iso
-application/oda					oda
+application/ODA					oda
 application/odm+xml
 application/ODX					odx
 application/oebps-package+xml			opf
 application/ogg					ogx
+application/opc-nodeset+xml     
 application/oscore
 application/oxps				oxps
 application/p2p-overlay+xml			relo
@@ -298,6 +307,7 @@ application/problem+xml
 application/provenance+xml			provx
 application/prs.alvestrand.titrax-sheet
 application/prs.cww				cw cww
+application/prs.cyn
 application/prs.hpub+zip			hpub
 application/prs.nprend				rnd rct
 application/prs.plucker
@@ -305,7 +315,7 @@ application/prs.rdf-xml-crypt			rdf-crypt
 application/prs.xsf+xml				xsf
 application/pskc+xml				pskcxml
 application/pvd+json
-application/qsig
+application/QSIG
 application/raptorfec
 application/rdap+json
 application/rdf+xml				rdf
@@ -332,6 +342,8 @@ application/rtploopback
 application/rtx
 application/samlassertion+xml
 application/samlmetadata+xml
+application/sarif-external-properties+json sarif-external-properties sarif-external-properties.json
+application/sarif+json          sarif sarif.json
 application/sbe
 application/sbml+xml
 application/scaip+xml
@@ -360,13 +372,15 @@ application/set-payment
 application/set-payment-initiation
 application/set-registration
 application/set-registration-initiation
-application/sgml
+application/SGML
 application/sgml-open-catalog			soc
 application/shf+xml				shf
 application/sieve				siv sieve
 application/simple-filter+xml			cl
 application/simple-message-summary
 application/simpleSymbolContainer
+# h5: application/mipc
+application/sipc
 application/slate
 # application/smil obsoleted by application/smil+xml
 application/smil+xml				smil smi sml
@@ -422,12 +436,18 @@ application/vcard+json
 application/vcard+xml
 application/vemmi
 application/vnd.1000minds.decision-model+xml	1km
+application/vnd.3gpp.5gnas              
 application/vnd.3gpp.access-transfer-events+xml
 application/vnd.3gpp.bsf+xml
 application/vnd.3gpp.GMOP+xml
+application/vnd.3gpp.gtpc
+application/vnd.3gpp.interworking-data
+application/vnd.3gpp.lpp
 application/vnd.3gpp.mc-signalling-ear
 application/vnd.3gpp.mcdata-affiliation-command+xml
 application/vnd.3gpp.mcdata-info+xml
+application/vnd.3gpp.mcdata-payload
+application/vnd.3gpp.mcdata-service-config+xml
 application/vnd.3gpp.mcdata-signalling
 application/vnd.3gpp.mcdata-ue-config+xml
 application/vnd.3gpp.mcdata-user-profile+xml
@@ -450,10 +470,13 @@ application/vnd.3gpp.mcvideo-transmission-request+xml
 application/vnd.3gpp.mcvideo-ue-config+xml
 application/vnd.3gpp.mcvideo-user-profile+xml
 application/vnd.3gpp.mid-call+xml
+application/vnd.3gpp.ngap
+application/vnd.3gpp.pfcp
 application/vnd.3gpp.pic-bw-large		plb
 application/vnd.3gpp.pic-bw-small		psb
 application/vnd.3gpp.pic-bw-var			pvb
 application/vnd.3gpp-prose+xml
+application/vnd.3gpp.s1ap
 application/vnd.3gpp-prose-pc3ch+xml
 # sms: application/vnd.3gpp2.sms
 application/vnd.3gpp.sms
@@ -481,10 +504,12 @@ application/vnd.adobe.xfdf			xfdf
 application/vnd.aether.imp
 application/vnd.afpc.afplinedata
 application/vnd.afpc.afplinedata-pagedef
+application/vnd.afpc.cmoca-cmresource
 application/vnd.afpc.foca-charset
 application/vnd.afpc.foca-codedfont
 application/vnd.afpc.foca-codepage
 application/vnd.afpc.modca			list3820 listafp afp pseg3820
+application/vnd.afpc.modca-cmtable
 application/vnd.afpc.modca-formdef
 application/vnd.afpc.modca-mediummap
 application/vnd.afpc.modca-objectcontainer
@@ -509,7 +534,7 @@ application/vnd.antix.game-component
 application/vnd.apache.thrift.binary
 application/vnd.apache.thrift.compact
 application/vnd.apache.thrift.json
-application/vnd.api+json    json-api
+application/vnd.api+json
 application/vnd.aplextor.warrp+json
 application/vnd.apothekende.reservation+json
 application/vnd.apple.installer+xml		dist distz pkg mpkg
@@ -589,6 +614,8 @@ application/vnd.crick.clicker.wordbank		clkw
 application/vnd.criticaltools.wbs+xml		wbs
 application/vnd.cryptii.pipe+json
 application/vnd.crypto-shade-file		ssvc
+application/vnd.cryptomator.encrypted   c9r c9s
+application/vnd.cryptomator.vault       cryptomator
 application/vnd.ctc-posml			pml
 application/vnd.ctct.ws+xml
 application/vnd.cups-pdf
@@ -599,7 +626,15 @@ application/vnd.cups-raw
 application/vnd.curl				curl
 application/vnd.cyan.dean.root+xml
 application/vnd.cybank
+# json: application/json
+application/vnd.cyclonedx+json
+# xml: text/xml
+application/vnd.cyclonedx+xml
 application/vnd.d2l.coursepackage1p0+zip
+# json: application/json
+application/vnd.d3m-dataset
+# json: application/json
+application/vnd.d3m-problem
 application/vnd.dart				dart
 application/vnd.data-vision.rdz			rdz
 application/vnd.datapackage+json
@@ -661,9 +696,9 @@ application/vnd.ecowin.series
 application/vnd.ecowin.seriesrequest
 application/vnd.ecowin.seriesupdate
 # img: application/octet-stream
-application/vnd.efi-img
+application/vnd.efi.img
 # iso: application/octet-stream
-application/vnd.efi-iso
+application/vnd.efi.iso
 application/vnd.emclient.accessrequest+xml
 application/vnd.enliven				nml
 application/vnd.enphase.envoy
@@ -725,6 +760,12 @@ application/vnd.framemaker			fm
 application/vnd.frogans.fnc			fnc
 application/vnd.frogans.ltf			ltf
 application/vnd.fsc.weblaunch			fsc
+# xdw: application/vnd.fujixerox.docuworks
+application/vnd.fujifilm.fb.docuworks
+# xbd: application/vnd.fujixerox.docuworks.binder
+application/vnd.fujifilm.fb.docuworks.binder
+# xct: application/vnd.fujixerox.docuworks.container
+application/vnd.fujifilm.fb.docuworks.container
 application/vnd.fujitsu.oasys			oas
 application/vnd.fujitsu.oasys2			oa2
 application/vnd.fujitsu.oasys3			oa3
@@ -733,9 +774,9 @@ application/vnd.fujitsu.oasysprs		bh2
 application/vnd.fujixerox.ART-EX
 application/vnd.fujixerox.ART4
 application/vnd.fujixerox.ddd			ddd
-application/vnd.fujixerox.docuworks		xdw
-application/vnd.fujixerox.docuworks.binder	xbd
-application/vnd.fujixerox.docuworks.container	xct
+application/vnd.fujixerox.docuworks     xdw
+application/vnd.fujixerox.docuworks.binder      xbd
+application/vnd.fujixerox.docuworks.container       xct
 application/vnd.fujixerox.HBPL
 application/vnd.fut-misnet
 application/vnd.futoin+cbor
@@ -746,6 +787,7 @@ application/vnd.gentics.grd+json
 # application/vnd.geo+json obsoleted by application/geo+json
 application/vnd.geocube+xml			g3 g³
 application/vnd.geogebra.file			ggb
+application/vnd.geogebra.slides         ggs
 application/vnd.geogebra.tool			ggt
 application/vnd.geometry-explorer		gex gre
 application/vnd.geonext				gxt
@@ -865,6 +907,7 @@ application/vnd.kidspiration			kia
 application/vnd.Kinar				kne knp sdf
 application/vnd.koan				skp skd skm skt
 application/vnd.kodak-descriptor		sse
+application/vnd.las                 las
 application/vnd.las.las+json			lasjson
 application/vnd.las.las+xml			lasxml
 application/vnd.laszip
@@ -973,6 +1016,7 @@ application/vnd.mynfc				taglet
 application/vnd.ncd.control
 application/vnd.ncd.reference
 application/vnd.nearst.inv+json
+application/vnd.nebumind.line       nebul line
 application/vnd.nervana				entity request bkm kcm
 application/vnd.netfpx
 application/vnd.nimn				nimn
@@ -1065,6 +1109,7 @@ application/vnd.oma.dcdc
 application/vnd.oma.dd2+xml			dd2
 application/vnd.oma.drm.risd+xml
 application/vnd.oma.group-usage-list+xml
+application/vnd.oma.lwm2m+cbor
 application/vnd.oma.lwm2m+json
 application/vnd.oma.lwm2m+tlv
 application/vnd.oma.pal+xml
@@ -1181,6 +1226,7 @@ application/vnd.oxli.countgraph			oxlicg
 application/vnd.pagerduty+json
 application/vnd.palm				prc pdb pqa oprc
 application/vnd.panoply				plp
+application/vnd.paos.xml
 application/vnd.paos+xml
 application/vnd.patentdive			dive
 application/vnd.patientecommsdoc
@@ -1188,7 +1234,7 @@ application/vnd.pawaafile			paw
 application/vnd.pcos
 application/vnd.pg.format		    	str
 application/vnd.pg.osasli			ei6
-application/vnd.piaccess.application-license	pil
+application/vnd.piaccess.application-licence	pil
 application/vnd.picsel				efif
 application/vnd.pmi.widget			wg
 application/vnd.poc.group-advertisement+xml
@@ -1260,6 +1306,8 @@ application/vnd.sealed.xls			sxls sxl s1e
 application/vnd.sealedmedia.softseal.html	stml s1h
 application/vnd.sealedmedia.softseal.pdf	spdf spd s1a
 application/vnd.seemail				see
+# json: application/json
+application/vnd.seis+json
 application/vnd.sema				sema
 application/vnd.semd				semd
 application/vnd.semf				semf
@@ -1296,6 +1344,7 @@ application/vnd.sun.wadl+xml			wadl
 application/vnd.sus-calendar			sus susp
 application/vnd.svd
 application/vnd.swiftview-ics
+application/vnd.sycle+xml           scl
 application/vnd.syncml+xml			xsm
 application/vnd.syncml.dm+wbxml			bdm
 application/vnd.syncml.dm+xml			xdm
@@ -1361,6 +1410,7 @@ application/vnd.wap.wbxml			wbxml
 application/vnd.wap.wmlc			wmlc
 application/vnd.wap.wmlscriptc			wmlsc
 application/vnd.webturbo			wtb
+application/vnd.wfa.dpp
 application/vnd.wfa.p2p				p2p
 application/vnd.wfa.wsc				wsc
 application/vnd.windows.devicepairing
@@ -1405,6 +1455,8 @@ application/vnd.zul				zir zirz
 application/vnd.zzazz.deck+xml			zaz
 application/voicexml+xml			vxml
 application/voucher-cms+json			vcj
+application/vq-rtcpxr
+application/wasm                    wasm
 application/vq-rtcp-xr
 application/watcherinfo+xml			wif
 application/webpush-options+json
@@ -1552,16 +1604,18 @@ audio/PCMA-WB
 audio/PCMU
 audio/PCMU-WB
 audio/prs.sid					sid psid
-audio/qcelp					qcp
+audio/QCELP					qcp
 audio/raptorfec
 audio/RED
 audio/rtp-enc-aescm128
 audio/rtp-midi
 audio/rtploopback
 audio/rtx
+audio/scip
 audio/SMV					smv
 # qcp: audio/qcelp, see RFC 3625
 audio/SMV-QCP
+audio/sofa                  sofa
 audio/SMV0
 # mid: audio/midi
 audio/sp-midi
@@ -1572,6 +1626,7 @@ audio/telephone-event
 audio/TETRA_ACELP
 audio/TETRA_ACELP_BB
 audio/tone
+audio/TSVCIS
 audio/UEMCLIP
 audio/ulpfec
 audio/usac					loas xhe
@@ -1579,7 +1634,7 @@ audio/VDVI
 audio/VMR-WB
 audio/vnd.3gpp.iufp
 audio/vnd.4SB
-audio/vnd.audikoz				koz
+audio/vnd.audiokoz				koz
 audio/vnd.CELP
 audio/vnd.cisco.nse
 audio/vnd.cmles.radio-events
@@ -1632,6 +1687,9 @@ font/woff2					woff2
 image/aces					exr
 image/avci					avci
 image/avcs					avcs
+# heif: image/heif
+# heifs: images/heif-sequence
+image/avif                  avif hif
 image/bmp					bmp dib
 image/cgm					cgm
 image/dicom-rle					drle
@@ -1654,6 +1712,7 @@ image/jphc					jhc
 image/jpeg					jpg jpeg jpe jfif
 image/jpm					jpm jpgm
 image/jpx					jpx jpf
+image/jxl                   jxl
 image/jxr					jxr
 image/jxrA					jxra
 image/jxrS					jxrs
@@ -1662,6 +1721,7 @@ image/jxsc					jxsc
 image/jxsi					jxsi
 image/jxss					jxss
 image/ktx					ktx
+image/ktx2                  ktx2
 image/naplps
 image/png					png
 image/prs.btif					btif btf
@@ -1691,6 +1751,7 @@ image/vnd.mix
 image/vnd.mozilla.apng				apng
 image/vnd.ms-modi				mdi
 image/vnd.net-fpx
+image/vnd.pco.b16               b16
 image/vnd.radiance				hdr rgbe xyze
 image/vnd.sealed.png				spng spn s1n
 image/vnd.sealedmedia.softseal.gif		sgif sgi s1g
@@ -1727,6 +1788,7 @@ message/vnd.si.simp
 message/vnd.wfa.wsc
 # 3mf: application/vnd.ms-3mfdocument
 model/3mf
+model/e57
 model/example
 model/gltf-binary				glb
 model/gltf+json					gltf
@@ -1747,7 +1809,9 @@ model/vnd.mts					mts
 model/vnd.opengex				ogex
 model/vnd.parasolid.transmit.binary		x_b xmt_bin
 model/vnd.parasolid.transmit.text		x_t xmt_txt
+model/vnd.pytha.pyox            pyo pyox
 model/vnd.rosette.annotated-data-model
+model/vnd.sap.vds               vds
 model/vnd.usdz+zip				usdz
 model/vnd.valve.source.compiled-map		bsp
 model/vnd.vtu					vtu
@@ -1776,17 +1840,22 @@ multipart/x-mixed-replace
 text/1d-interleaved-parityfec
 text/cache-manifest				appcache manifest
 text/calendar					ics ifb
+text/cql                    CQL
+text/cql-expression
+text/cql-identifier
 text/css					css
 text/csv					csv
 text/csv-schema					csvs
 text/directory
 text/dns					soa zone
 text/encaprtp
+text/fhirpath
 # text/ecmascript obsoleted by application/ecmascript
 text/enriched
 text/example
 text/flexfec
 text/fwdred
+text/gff3                   gff3
 text/grammar-ref-list
 text/html					html htm
 # text/javascript obsoleted by application/javascript
@@ -1810,7 +1879,9 @@ text/rtf
 text/rtp-enc-aescm128
 text/rtploopback
 text/rtx
-text/sgml					sgml sgm
+text/SGML					sgml sgm
+text/shaclc                 shaclc shc
+text/spdx                   spdx
 text/strings
 text/t140
 text/tab-separated-values			tsv
@@ -1834,6 +1905,7 @@ text/vnd.fmi.flexstor				flx
 # gml: application/gml+xml
 text/vnd.gml
 text/vnd.graphviz				gv dot
+text/vnd.hans                   hans
 text/vnd.hgl					hgl
 text/vnd.in3d.3dml				3dml 3dm
 text/vnd.in3d.spot				spot spo
@@ -1860,11 +1932,13 @@ video/1d-interleaved-parityfec
 video/3gpp					3gp 3gpp
 video/3gpp2					3g2 3gpp2
 video/3gpp-tt
+video/AV1
 video/BMPEG
 video/BT656
 video/CelB
 video/DV
 video/encaprtp
+video/FFV1
 video/example
 video/flexfec
 video/H261
@@ -1897,6 +1971,7 @@ video/raw
 video/rtp-enc-aescm128
 video/rtploopback
 video/rtx
+video/scip
 video/smpte291
 video/SMPTE292M
 video/ulpfec

--- a/priv/mime.types
+++ b/priv/mime.types
@@ -534,7 +534,7 @@ application/vnd.antix.game-component
 application/vnd.apache.thrift.binary
 application/vnd.apache.thrift.compact
 application/vnd.apache.thrift.json
-application/vnd.api+json
+application/vnd.api+json    json-api
 application/vnd.aplextor.warrp+json
 application/vnd.apothekende.reservation+json
 application/vnd.apple.installer+xml		dist distz pkg mpkg

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -11,7 +11,7 @@ defmodule MIMETest do
 
   test "extensions/1" do
     assert extensions("application/json") == ["json"]
-    assert extensions("application/vnd.api+json") == ["json"]
+    assert extensions("application/vnd.api+json") == ["json-api"]
     assert extensions("audio/amr") == ["amr"]
     assert extensions("IMAGE/PNG") == ["png"]
 

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -11,7 +11,7 @@ defmodule MIMETest do
 
   test "extensions/1" do
     assert extensions("application/json") == ["json"]
-    assert extensions("application/vnd.api+json") == ["json-api"]
+    assert extensions("application/vnd.api+json") == ["json"]
     assert extensions("audio/amr") == ["amr"]
     assert extensions("IMAGE/PNG") == ["png"]
 


### PR DESCRIPTION
Recently we started to serving wasm files via phoenix, and Plug.Static set the wrong mime type for them. This update addresses it.