### PR TITLE
Add the `svgz` extension to the `svg` mimetype

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -80,7 +80,7 @@ defmodule MIME do
     "image/gif" => ["gif"],
     "image/jpeg" => ["jpg", "jpeg"],
     "image/png" => ["png"],
-    "image/svg+xml" => ["svg"],
+    "image/svg+xml" => ["svg", "svgz"],
     "image/tiff" => ["tiff", "tif"],
     "image/vnd.microsoft.icon" => ["ico"],
     "image/webp" => ["webp"],


### PR DESCRIPTION
Files with the svgz extension are compressed svg files. This adds support for them. 

Motivation: I have an app in production that accepts svgz uploads on a LiveView page, which does not work without this patch.