### PR TITLE
ft: add the MIME type for markdown files

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -94,6 +94,7 @@ defmodule MIME do
     "text/csv" => ["csv"],
     "text/html" => ["html", "htm"],
     "text/javascript" => ["js", "mjs"],
+    "text/markdown" => ["md", "markdown"],
     "text/plain" => ["txt", "text"],
     "text/xml" => ["xml"],
     "video/3gpp" => ["3gp"],


### PR DESCRIPTION
Adds the MIME type for markdown files.

https://www.iana.org/assignments/media-types/text/markdown