### PR TITLE
Fix failing CI by using latest ubuntu runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     strategy:
@@ -17,7 +17,7 @@ jobs:
         include:
           - pair:
               elixir: 1.11.4
-              otp: 23.2.7
+              otp: 23.2
             lint: lint
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The ubuntu-16.04 machine image for running jobs has not been available for some months, so this PR brings the CI in-line with that used in other elixir-plug projects.