### PR TITLE
Only return extensions for known structured syntax suffixes

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -117,6 +117,14 @@ defmodule MIME do
     "video/x-msvideo" => ["avi"]
   }
 
+  #selected from https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xhtml
+  suffixes = %{
+    "gzip" => ["gz"],
+    "json" => ["json"],
+    "xml" => ["xml"],
+    "zip" => ["zip"]
+  }
+
   require Application
   custom_types = Application.compile_env(:mime, :types, %{})
 
@@ -177,7 +185,7 @@ defmodule MIME do
 
   defp suffix(type) do
     case String.split(type, "+") do
-      [_type_subtype_without_suffix, suffix] -> [suffix]
+      [_type_subtype_without_suffix, suffix] -> suffix_to_ext(suffix)
       _ -> nil
     end
   end
@@ -265,4 +273,13 @@ defmodule MIME do
   end
 
   defp mime_to_ext(_type), do: nil
+
+  @spec suffix_to_ext(String.t()) :: list(String.t()) | nil
+  defp suffix_to_ext(suffix)
+
+  for {suffix, exts} <- suffixes do
+    defp suffix_to_ext(unquote(suffix)), do: unquote(List.wrap(exts))
+  end
+
+  defp suffix_to_ext(_suffix), do: nil
 end

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -20,6 +20,8 @@ defmodule MIMETest do
     assert extensions("application/xml") == ["xml"]
     assert extensions("application/vnd.custom+xml") == ["xml"]
     assert extensions("application/vnd.custom+xml+xml") == []
+    assert extensions("application/vnd.custom+inexist") == []
+    assert extensions("application/vnd.custom+xml/extrainvalid") == []
   end
 
   test "type/1" do


### PR DESCRIPTION
While examining the new example code for Phoenix Liveview uploads introduced in this pull request https://github.com/phoenixframework/phoenix_live_view/pull/2555 , I noticed a security issue if the MIME type sent by the client is changed maliciously to something like:
`image/jpeg+test/live_view_upload-1685392969-33687532766-2.jpg`

The Mime.extensions method will return an extension of:
`test/live_view_upload-1685392969-33687532766-2.jpg`
So in the example the selected name live_view_upload-1685392969-33687532766-2.jpg replaces the randomly selected name from Plug. This allows overwriting arbitrary files within the upload directory. Though it is not possible to escape the directory due to the use of Path.basename in the example.

This seems an easy mistake to make, and that it would be better if the MIME.extension method protected against this by only returning an extension based on the suffix if it is one of the well known ones. The [official register of suffixes](https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xhtml) includes some that seem very obscure so I have just picked the ones with extensions that appear already in the database in this module. These might also be worth including:
```
sqlite3 => ["sqlite", "sqlite3", "db"]
yaml => ["yaml", "yml"] 
```
(YAML suffix [appears about to be standardised](https://www.ietf.org/id/draft-ietf-httpapi-yaml-mediatypes-06.html ))
