### PR TITLE
Add known_types/0 function that lists all known types

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -167,9 +167,15 @@ defmodule MIME do
   @doc """
   Returns a mapping of all known types to their extensions,
   including custom types compiled into the MIME module.
+  
+  ## Examples
+  
+      known_types()
+      #=> %{"application/json" => ["json"], ...}
+
   """
   @doc since: "2.1.0"
-  @spec known_types() :: %{String.t() => [String.t()]}
+  @spec known_types() :: %{required(String.t()) => [String.t()]}
   def known_types do
     unquote(Macro.escape(all_types))
   end

--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -165,10 +165,13 @@ defmodule MIME do
   end
 
   @doc """
-  Returns a list of all known types, including custom types compiled into the MIME module.
+  Returns a mapping of all known types to their extensions,
+  including custom types compiled into the MIME module.
   """
+  @doc since: "2.1.0"
+  @spec known_types() :: %{String.t() => [String.t()]}
   def known_types do
-    Map.keys(unquote(Macro.escape(all_types)))
+    unquote(Macro.escape(all_types))
   end
 
   @doc """

--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -165,6 +165,13 @@ defmodule MIME do
   end
 
   @doc """
+  Returns a list of all known types, including custom types compiled into the MIME module.
+  """
+  def known_types do
+    Map.keys(unquote(Macro.escape(all_types)))
+  end
+
+  @doc """
   Returns the extensions associated with a given MIME type.
 
   ## Examples

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -49,6 +49,19 @@ defmodule MIMETest do
     assert from_path("image.psd") == "image/vnd.adobe.photoshop"
   end
 
+  test "known_types/0" do
+    Application.put_env(:mime, :types, %{"application/dicom" => ["dcm"]})
+    recompile!()
+
+    assert is_map(known_types())
+
+    assert Map.has_key?(known_types(), "application/json")
+    assert Map.has_key?(known_types(), "application/dicom")
+
+    assert Map.get(known_types(), "application/json") == ["json"]
+    assert Map.get(known_types(), "application/dicom") == ["dcm"]
+  end
+
   test "types map is sorted" do
     quoted = Code.string_to_quoted!(File.read!("lib/mime.ex"))
 


### PR DESCRIPTION
Adds a `known_types/0` function that returns a list of all known types. Fixes #75.

```
iex(1)> MIME.known_types
["image/bmp", "application/json-patch+json",
 "application/vnd.oasis.opendocument.spreadsheet", "application/zip",
 "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 "application/xhtml+xml", "application/x-bzip2", "application/manifest+json",
 "application/vnd.ms-powerpoint", "application/json", "video/mpeg",
 "application/x-7z-compressed", "video/mp4",
 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 "text/css", "application/vnd.etsi.asic-e+zip", "text/xml", "text/plain",
 "audio/aac", "image/svg+xml", "video/x-msvideo", "image/heic", "image/avif",
 "text/html",
 "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 "application/x-abiword", "application/postscript", "video/ogg", "audio/opus",
 "application/x-freearc", "audio/webm", "font/woff", "text/markdown",
 "application/x-httpd-php", "audio/wav", "application/vnd.amazon.ebook",
 "application/x-bzip", "application/rss+xml", "image/png", "application/ogg",
 "application/wasm", "application/x-cdf", "video/x-ms-wmv", "audio/midi",
 "video/webm", "video/quicktime", "image/jpeg", "image/vnd.adobe.photoshop",
 "text/calendar", "video/3gpp2", ...]
```
