### PR TITLE
Add `application/zstd` (Zstandard)

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -154,7 +154,8 @@ defmodule MIME do
     "gzip" => ["gz"],
     "json" => ["json"],
     "xml" => ["xml"],
-    "zip" => ["zip"]
+    "zip" => ["zip"],
+    "zstd" => ["zst"]
   }
 
   custom_suffixes = Application.compile_env(:mime, :suffixes, %{})

--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -79,6 +79,7 @@ defmodule MIME do
     "application/xhtml+xml" => ["xhtml"],
     "application/xml" => ["xml"],
     "application/zip" => ["zip"],
+    "application/zstd" => ["zst"],
     "audio/3gpp" => ["3gp"],
     "audio/3gpp2" => ["3g2"],
     "audio/aac" => ["aac"],


### PR DESCRIPTION
- https://en.wikipedia.org/wiki/Zstd
- [RFC 8878](https://datatracker.ietf.org/doc/html/rfc8878)
- [IANA Assignment](https://www.iana.org/assignments/media-types/application/zstd)
- Adds support for media type and [`+zstd` structured syntax suffix](https://datatracker.ietf.org/doc/html/rfc8878#name-structured-syntax-suffix), i.e. `application/csv+zstd`