### PR TITLE
Add m4v extension for video/mp4

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -119,7 +119,7 @@ defmodule MIME do
     "video/3gpp" => ["3gp"],
     "video/3gpp2" => ["3g2"],
     "video/mp2t" => ["ts"],
-    "video/mp4" => ["mp4"],
+    "video/mp4" => ["mp4", "m4v"],
     "video/mpeg" => ["mpeg", "mpg"],
     "video/ogg" => ["ogv"],
     "video/quicktime" => ["mov"],


### PR DESCRIPTION
This adds support for recognizing the `m4v` extension as a video (and optionally audio) file encoded in an `mp4` container and therefore slotting under the `video/mp4` mime type.

The `m4v` file extension has a slightly muddied description on the internet with some sources indicating it is technically not necessarily a video in an MP4 container. However, in my experience, it is most commonly seen as the format Apple invented to take MP4 and optionally include DRM alongside it. I think if you are given an `m4v` file and must guess what mime type it should have with no other information, you gotta go with `video/mp4`.