### PR TITLE
fix extension name for jp2

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -99,7 +99,7 @@ defmodule MIME do
     "image/gif" => ["gif"],
     "image/heic" => ["heic"],
     "image/heif" => ["heif"],
-    "image/jp2" => [".jp2"],
+    "image/jp2" => ["jp2"],
     "image/jpeg" => ["jpg", "jpeg"],
     "image/jxl" => ["jxl"],
     "image/png" => ["png"],

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -30,6 +30,13 @@ defmodule MIMETest do
     assert extensions("application/vnd.custom+xml/extrainvalid") == []
   end
 
+  test "extensions must not lead with a dot" do
+    for {type, exts} <- known_types(), ext <- exts do
+      expected = String.replace_leading(ext, ".", "")
+      assert expected == ext, "type '#{type}' includes '#{ext}', replace it with '#{expected}'."
+    end
+  end
+
   test "type/1" do
     assert type("json") == "application/json"
     assert type("foo") == "application/octet-stream"


### PR DESCRIPTION
The extension for `.jp2` includes a leading dot, which shouldn't happen. I also added a unit test to prevent this from happening in the future.